### PR TITLE
Send an error callback for all OSErrors

### DIFF
--- a/ptero_shell_command/implementation/celery_tasks/shell_command.py
+++ b/ptero_shell_command/implementation/celery_tasks/shell_command.py
@@ -42,7 +42,8 @@ class ShellCommandTask(celery.Task):
                 self.callback('error', callbacks, jobId=self.request.id,
                     errorMessage='Command not found: %s' % command_line[0])
             else:
-                raise e
+                self.callback('error', callbacks, jobID=self.request.id,
+                        errorMessage=e.message)
             return False
 
     def callback(self, status, callbacks, **kwargs):


### PR DESCRIPTION
I was running into some of these exceptions while bringing workflow up to date with this repo.  It's much easier to debug if we just send along an error message.
