### PR TITLE
Support multiple webhooks with the same name

### DIFF
--- a/ptero_shell_command/api/v1/schemas/post_job.json
+++ b/ptero_shell_command/api/v1/schemas/post_job.json
@@ -7,7 +7,16 @@
             "type": "string",
             "description": "TODO does the 'uri' format enforce a non-zero length? do we want to enforce that?",
             "format": "uri"
-        }
+        },
+        "webhook_list": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/webhook" },
+            "minItems": 1
+        },
+        "webhook_entry": { "oneOf": [
+            { "$ref": "#/definitions/webhook" },
+            { "$ref": "#/definitions/webhook_list" }
+        ]}
     },
     "type": "object",
     "properties": {
@@ -36,11 +45,11 @@
         "webhooks": {
             "type": "object",
             "properties": {
-                "begun": { "$ref": "#/definitions/webhook" },
-                "ended": { "$ref": "#/definitions/webhook" },
-                "error": { "$ref": "#/definitions/webhook" },
-                "success": { "$ref": "#/definitions/webhook" },
-                "failure": { "$ref": "#/definitions/webhook" }
+                "begun": { "$ref": "#/definitions/webhook_entry" },
+                "ended": { "$ref": "#/definitions/webhook_entry" },
+                "error": { "$ref": "#/definitions/webhook_entry" },
+                "success": { "$ref": "#/definitions/webhook_entry" },
+                "failure": { "$ref": "#/definitions/webhook_entry" }
             },
             "additionalProperties": false
         },

--- a/ptero_shell_command/implementation/celery_tasks/shell_command.py
+++ b/ptero_shell_command/implementation/celery_tasks/shell_command.py
@@ -87,7 +87,12 @@ class ShellCommandTask(celery.Task):
 
         if webhook_name in webhooks:
             task = self._get_http_task()
-            task.delay('PUT', webhooks[webhook_name], **kwargs)
+            urls = webhooks[webhook_name]
+            if not isinstance(urls, list):
+                urls = [urls]
+
+            for url in urls:
+                task.delay('PUT', url, **kwargs)
 
     def _get_http_task(self):
         return celery.current_app.tasks[

--- a/tests/api/v1/test_webhooks.py
+++ b/tests/api/v1/test_webhooks.py
@@ -150,6 +150,31 @@ class TestWebhooks(BaseAPITest):
         ]
         self.assertEqual(expected_data, webhook_data)
 
+    def test_list_of_webhooks(self):
+        webhook_target = self.create_webhook_server([200, 200])
+
+        post_response = self.post(self.jobs_url, {
+            'commandLine': ['true'],
+            'user': self.job_user,
+            'workingDirectory': self.job_working_directory,
+            'webhooks': {
+                'begun': [webhook_target.url, webhook_target.url]
+            },
+        })
+
+        webhook_data = webhook_target.stop()
+        expected_data = [
+            {
+                'status': 'running',
+                'jobId': post_response.DATA['jobId'],
+            },
+            {
+                'status': 'running',
+                'jobId': post_response.DATA['jobId'],
+            },
+        ]
+        self.assertEqual(expected_data, webhook_data)
+
     def test_environment_set_for_job(self):
         webhook_target = self.create_webhook_server([200])
         environment = {


### PR DESCRIPTION
This just seems nice to support.  Also I want to be able to declare webhooks for shell-command in the workflow.json and have them combined with the internal-use webhooks that the workflow service adds to the shell-command submission.  We will then be ready to add support for webhooks on any task or method of a workflow, so long as the method's service supports them (I think they all will).