### PR TITLE
Wait for Rabbitmq to spin-up before running tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,7 @@ commands =
 
     devserver --procfile {env:PTERO_SHELL_COMMAND_TEST_PROCFILE:{toxinidir}/tests/scripts/Procfile} --logdir {toxinidir}/var/log --daemondir {toxinidir}/var/run
     wait_for_service PTERO_SHELL_COMMAND_HOST PTERO_SHELL_COMMAND_PORT
+    wait_for_service PTERO_SHELL_COMMAND_HOST PTERO_SHELL_COMMAND_RABBITMQ_NODE_PORT
     coverage run {envbindir}/nosetests {posargs}
 
     teardown_devserver {toxinidir}/var/run/devserver.pid


### PR DESCRIPTION
I would like to eventually implement a more general solution, once I think of a general solution that I like.  For now, I think this will fix the build instability caused by the tests beginning to run before rabbitmq is ready.