### PR TITLE
Allow numbers in commandLine property

### DIFF
--- a/ptero_shell_command/api/v1/schemas/post_job.json
+++ b/ptero_shell_command/api/v1/schemas/post_job.json
@@ -23,7 +23,7 @@
         "commandLine": {
             "type": "array",
             "description": "TODO what happens when passing empty strings to commandLine/exec?",
-            "items": { "type": "string" },
+            "items": { "type": ["string", "number"] },
             "minItems": 1
         },
         "environment": {

--- a/ptero_shell_command/implementation/celery_tasks/shell_command.py
+++ b/ptero_shell_command/implementation/celery_tasks/shell_command.py
@@ -25,8 +25,8 @@ class ShellCommandTask(celery.Task):
 
         try:
             LOG.debug('command_line %s' % command_line)
-            p = subprocess.Popen(
-                command_line, env=environment, close_fds=True,
+            p = subprocess.Popen([str(x) for x in command_line],
+                env=environment, close_fds=True,
                 preexec_fn=lambda: self._setup_execution_environment(
                     umask, user, working_directory),
                 stdin=subprocess.PIPE,

--- a/tests/api/v1/test_bad_requests.py
+++ b/tests/api/v1/test_bad_requests.py
@@ -11,9 +11,12 @@ class TestBadRequests(BaseAPITest):
             'workingDirectory': self.job_working_directory,
         }
 
-    def _expect_400(self, data):
+    def _expect(self, data, status_code):
         post_response = self.post(self.jobs_url, data)
-        self.assertEqual(400, post_response.status_code)
+        self.assertEqual(status_code, post_response.status_code)
+
+    def _expect_400(self, data):
+        self._expect(data, 400)
 
     def test_empty_body(self):
         self._expect_400({})
@@ -27,8 +30,12 @@ class TestBadRequests(BaseAPITest):
         self.valid_request_data['commandLine'] = []
         self._expect_400(self.valid_request_data)
 
-    def test_command_line_contains_non_strings(self):
+    def test_command_line_contains_numbers(self):
         self.valid_request_data['commandLine'] = ['foo', 1, 'bar']
+        self._expect(self.valid_request_data, 201)
+
+    def test_command_line_contains_non_strings(self):
+        self.valid_request_data['commandLine'] = ['foo', True, 'bar']
         self._expect_400(self.valid_request_data)
 
     def test_user_non_string_integer(self):


### PR DESCRIPTION
Because the JSON encoder in Perl cannot tell the difference between a
number and a string representing a number, it encodes it as a number.
This means that without this change, one cannot (from perl) request any
jobs that have a commandLine that includes a numeric argument.

subprocess.Popen requires that all arguments are strings though, so we
cannot just let the numeric arguments pass straight through.