### PR TITLE
Set groups, and gid in addition to uid

### DIFF
--- a/ptero_shell_command/implementation/celery_tasks/shell_command.py
+++ b/ptero_shell_command/implementation/celery_tasks/shell_command.py
@@ -101,7 +101,11 @@ class ShellCommandTask(celery.Task):
         ]
 
     def _setup_execution_environment(self, umask, user, working_directory):
-        self._set_uid(user)
+        pw_ent = self._get_pw_ent(user)
+        self._set_groups(user, pw_ent.pw_gid)
+        self._set_gid(pw_ent.pw_gid)
+        self._set_uid(pw_ent.pw_uid)
+
         self._set_umask(umask)
         self._set_working_directory(working_directory)
 
@@ -112,14 +116,28 @@ class ShellCommandTask(celery.Task):
             except TypeError as e:
                 raise PreExecFailed('Failed to set umask: ' + e.message)
 
-    def _set_uid(self, user):
+    def _get_pw_ent(self, user):
         try:
             pw_ent = pwd.getpwnam(user)
         except KeyError as e:
             raise PreExecFailed(e.message)
+        return pw_ent
 
+    def _set_groups(self, user, gid):
         try:
-            os.setreuid(pw_ent.pw_uid, pw_ent.pw_uid)
+            os.initgroups(user, gid)
+        except OSError as e:
+            raise PreExecFailed('Failed to initgroups: ' + e.strerror)
+
+    def _set_gid(self, gid):
+        try:
+            os.setregid(gid, gid)
+        except OSError as e:
+            raise PreExecFailed('Failed to setregid: ' + e.strerror)
+
+    def _set_uid(self, uid):
+        try:
+            os.setreuid(uid, uid)
         except OSError as e:
             raise PreExecFailed('Failed to setreuid: ' + e.strerror)
 

--- a/tests/api/v1/test_drop_permissions.py
+++ b/tests/api/v1/test_drop_permissions.py
@@ -1,4 +1,5 @@
 from .base import BaseAPITest
+import pwd
 import os
 import re
 import unittest
@@ -61,6 +62,7 @@ class TestDropPermissions(BaseAPITest):
         webhook_target = self.create_webhook_server([200])
 
         user = 'nobody'
+        test_user = pwd.getpwuid(os.getuid())[0]
         post_response = self.post(self.jobs_url, {
             'commandLine': ['whoami'],
             'user': user,
@@ -75,7 +77,8 @@ class TestDropPermissions(BaseAPITest):
             {
                 'status': statuses.errored,
                 'jobId': post_response.DATA['jobId'],
-                'errorMessage': 'Failed to setreuid: Operation not permitted'
+                'errorMessage': 'Attempted submit job as invalid user (%s), '
+                                'only valid value is (%s)' % (user, test_user)
             }
         ]
         self.assertEqual(expected_data, webhook_data)


### PR DESCRIPTION
It seems that nfs looks at groups while performing root squashing.