### PR TITLE
Stop setting 'new' status twice

### DIFF
--- a/ptero_shell_command/implementation/backend.py
+++ b/ptero_shell_command/implementation/backend.py
@@ -33,10 +33,6 @@ class Backend(object):
                 working_directory=working_directory, **kwargs)
         self.session.add(job)
 
-        LOG.debug("Setting status of job (%s) to 'new'", job.id,
-                extra={'jobId': job.id})
-        self._set_job_status(job, statuses.new)
-
         LOG.debug("Commiting job (%s) to DB", job.id,
                 extra={'jobId': job.id})
         self.session.commit()


### PR DESCRIPTION
It is in the __init__ function already, don't do it here too.

closes #58 